### PR TITLE
don't crash if there are no dependencies

### DIFF
--- a/src/pdm_build_locked/_utils.py
+++ b/src/pdm_build_locked/_utils.py
@@ -112,6 +112,5 @@ def update_metadata_with_locked(metadata: dict[str, Any], root: Path) -> None:  
                     requirements.append(requirement_dict_to_string(package))
                 except UnsupportedRequirement as e:
                     print(f"Skipping unsupported requirement: {e}")
-        if not requirements:
-            raise UnsupportedRequirement(f"No valid PEP 508 requirements are found for group {group}")
+
         metadata.setdefault("optional-dependencies", {})[locked_group] = requirements


### PR DESCRIPTION
Hi @frostming , really liking your implementation and I think it's a great improvement :)

One thing had me scratching my head though, why crash with `UnsupportedRequirement` when there are no dependencies in pyproject.toml ?

I think it's valid to just continue in that case and add empty `optional-dependencies`.