### PR TITLE
fix: `include_metadata` typo and enhance documentation

### DIFF
--- a/doc/src/plugins/backend.rst
+++ b/doc/src/plugins/backend.rst
@@ -10,8 +10,12 @@ To set it up, a few configuration steps are required.
 Lockfile configuration
 ======================
 
-Your lockfile must be configured with the ``include_metadata`` strategy (``pdm>=2.11``) and include locks for the
-optional-dependencies groups you want to publish locked.
+Your lockfile must be configured with the ``inherit_metadata`` strategy (``pdm>=2.11``) and include locks for the optional-dependencies groups you want to publish locked.
+
+    .. note::
+        When running ``pdm lock``, ensure you select the appropriate dependency groups.
+
+        For instance, you can use ``pdm lock -G :all`` and then verify that the ``[metadata]`` section of the ``pdm.lock`` file includes the desired groups. For more details, refer to the ``Dependencies Selection:`` section in the ``pdm lock --help`` output.
 
 buildsystem configuration
 =========================


### PR DESCRIPTION
- Corrected the typo from `include_metadata` to `inherit_metadata` in the documentation.
- Added a note to clarify the usage of `pdm lock` with dependency groups.